### PR TITLE
Fix typo in model identifier for GPT-J 6b

### DIFF
--- a/ChatGPT_J.ipynb
+++ b/ChatGPT_J.ipynb
@@ -306,8 +306,8 @@
     {
       "cell_type": "code",
       "source": [
-        "config = transformers.GPTJConfig.from_pretrained(\"EleutherAI/gpt-j-6B\")\n",
-        "tokenizer = transformers.AutoTokenizer.from_pretrained(\"EleutherAI/gpt-j-6B\")"
+        "config = transformers.GPTJConfig.from_pretrained(\"EleutherAI/gpt-j-6b\")\n",
+        "tokenizer = transformers.AutoTokenizer.from_pretrained(\"EleutherAI/gpt-j-6b\")"
       ],
       "metadata": {
         "id": "D2UqDc77Ee6H"


### PR DESCRIPTION
This pull request fixes a typo in the model identifier for the GPT-J 6B model in the transformers package. The original identifier used a capital "B" instead of a lowercase "b", which caused an error when trying to use the model.

I have updated the identifier to use the correct lowercase "b", which resolves the error. This change is consistent with the model identifier convention established by Hugging Face.

This fix should make it easier for users to access and use the GPT-J 6B model without encountering errors.